### PR TITLE
Delete variables, don't try to fake them with trash content.

### DIFF
--- a/sites/all/modules/custom/druio_livetodev/druio_livetodev.module
+++ b/sites/all/modules/custom/druio_livetodev/druio_livetodev.module
@@ -220,18 +220,12 @@ function _druio_livetodev_scrub_data() {
   db_delete('hybridauth_session')->execute();
   db_delete('hybridauth_identity')->execute();
 
-  db_update('variable')
-    ->fields(array(
-      'value' => 's:4:\"fake\";',
-    ))
+  db_delete('variable')
     ->condition('name', db_like('hybridauth_') . '%%', 'LIKE')
     ->execute();
 
   // Remove mandrill API key.
-  db_update('variable')
-    ->fields(array(
-      'value' => 's:4:\"fake\";',
-    ))
+  db_delete('variable')
     ->condition('name', 'mandrill_api_key')
     ->execute();
 


### PR DESCRIPTION
After importing the DB into local environment there are these error messages:
"Notice: unserialize(): Error at offset 0 of 13 bytes in variable_initialize() (line 935 of /var/www/site/docroot/includes/bootstrap.inc)."

Variable check module shows that the issue is in hybridauth related variables and in mandrill_api_key variable. They all have the value `s:4:\"fake\";`
Let's just remove them and not try to fake them.
